### PR TITLE
Fixed definitively the encoding issues arising when computing the MD5…

### DIFF
--- a/secretballot/middleware.py
+++ b/secretballot/middleware.py
@@ -17,5 +17,16 @@ class SecretBallotIpMiddleware(SecretBallotMiddleware):
 
 class SecretBallotIpUseragentMiddleware(SecretBallotMiddleware):
     def generate_token(self, request):
-        s = u"".join((request.META['REMOTE_ADDR'], request.META.get('HTTP_USER_AGENT', '')))
-        return md5(s.encode('utf-8')).hexdigest()
+        addr = request.META['REMOTE_ADDR']
+        user_agent = request.META.get('HTTP_USER_AGENT', '')
+        s = "".join((addr, user_agent))
+        try:
+            # If s is a unicode string, this will work (Python3)
+            s = s.encode('utf-8')
+        except UnicodeDecodeError:
+            # Otherwise, s will raise a 'UnicodeDecodeError', meaning s
+            # is probably an already encoded string (Python2)
+            # We decode it and encode it again, to ensure it uses UTF-8
+            s = s.decode('utf-8').encode('utf-8')
+
+        return md5(s).hexdigest()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -66,7 +66,7 @@ class MiddlewareTestCase(TestCase):
         mw = SecretBallotIpUseragentMiddleware()
         r = HttpRequest()
         r.META['REMOTE_ADDR'] = '1.2.3.4'
-        r.META['HTTP_USER_AGENT'] = u"Orange España"
+        r.META['HTTP_USER_AGENT'] = 'Orange España'
         mw.process_request(r)
         token = r.secretballot_token
 


### PR DESCRIPTION
… digest from the request's address and user agent. Since the library is targeted at both Python2 and Python3, str objects behave diferently (Python3 str are unicode whereas Python2 str are encoded by default using ASCII encoding). 

Attempting to encode a Python3 str object using UTF8 encoding yields successfully. However, a Python2 str, which is already encoded using ASCII encoding by default, yields a UnicodeDecodeError when attempting to encode it using UTF8 encoding. One can decode the string and encode it again with the desired encoding. Python3 str do not have a 'decode' method, therefore these need to be handled separately. 

The try/except clause included in this commit performs the differentiated encoding/decoding approaches in Python2 and Python3 str objects.